### PR TITLE
Improved license generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ npm install -g angular-cli
 npm run test
 ```
 
+## Advanced options
+
+```sh
+yo ng2-alfresco-component --alfresco
+```
+
+Typically used for internal purposes and adds the following extras to the generated project structure:
+
+- adds Alfresco license headers to all code files
+- configures component `package.json` with additional license checker configurations (devDependencies, scripts, etc.)
+
 ## History
 
 For detailed changelog, see [Releases](https://github.com/Alfresco/generator-ng2-alfresco-component/releases).

--- a/app/alfresco-license-check.json
+++ b/app/alfresco-license-check.json
@@ -1,0 +1,17 @@
+{
+  "scripts": {
+    "license-check": "license-check"
+  },
+  "devDependencies": {
+    "license-check": "^1.0.4"
+  },
+  "license-check-config": {
+    "src": [
+      "./dist/**/*.js"
+    ],
+    "path": "assets/license_header.txt",
+    "blocking": false,
+    "logInfo": false,
+    "logError": true
+  }
+}

--- a/app/alfresco-license-header.ts
+++ b/app/alfresco-license-header.ts
@@ -1,0 +1,16 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/app/index.js
+++ b/app/index.js
@@ -14,7 +14,15 @@ function validateEmail(email) {
 module.exports = yeoman.Base.extend({
 
   initializing: function () {
-    this.props = {};
+    this.props = {
+      licenseHeader: '',
+      licenseChecker: false
+    };
+
+    if (this.options.alfresco) {
+      this.props.licenseHeader = this.fs.read(path.join(__dirname, './alfresco-license-header.ts'));
+      this.props.licenseChecker = true;
+    }
   },
 
   prompting: function () {
@@ -163,36 +171,25 @@ module.exports = yeoman.Base.extend({
     this.fs.copyTpl(
       this.templatePath('_angular-cli.json'),
       this.destinationPath('angular-cli.json'),
-      {
-        projectName: this.props.projectName
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('_index.ts'),
       this.destinationPath('index.ts'),
-      {
-        projectName: this.props.projectName,
-        projectNameCamelCase: this.props.projectNameCamelCase
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('_sourceFile.ts'),
       this.destinationPath('src/' + this.props.projectName + '.component.ts'),
-      {
-        projectName: this.props.projectName,
-        projectNameCamelCase: this.props.projectNameCamelCase
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('_testFile.spec.ts'),
       this.destinationPath('src/' + this.props.projectName + '.component.spec.ts'),
-      {
-        projectName: this.props.projectName,
-        projectNameCamelCase: this.props.projectNameCamelCase
-      }
+      this.props
     );
 
     mkdirp('src/app');
@@ -200,31 +197,30 @@ module.exports = yeoman.Base.extend({
     this.fs.copyTpl(
       this.templatePath('_package.json'),
       this.destinationPath('package.json'),
-      {
-        projectName: this.props.projectName,
-        description: this.props.description,
-        authorName: this.props.authorName,
-        githubAccount: this.props.githubAccount
-      }
+      this.props
     );
 
     var currentPkg = this.fs.readJSON(this.destinationPath('package.json'), {});
     this.props.keywords.push('alfresco-component');
 
-    var pkg = _.extend({
-      keywords: this.props.keywords
-    }, currentPkg);
+    var pkg = _.merge(
+      currentPkg,
+      { keywords: this.props.keywords }
+    );
+
+    if (this.props.licenseChecker) {
+      pkg = _.merge(
+          currentPkg,
+          this.fs.readJSON(path.join(__dirname, './alfresco-license-check.json'), {})
+      );
+    }
 
     this.fs.writeJSON(this.destinationPath('package.json'), pkg);
 
     this.fs.copyTpl(
       this.templatePath('_README.md'),
       this.destinationPath('README.md'),
-      {
-        projectName: this.props.projectName,
-        description: this.props.description,
-        githubAccount: this.props.githubAccount
-      }
+      this.props
     );
 
     this.composeWith('license', {
@@ -244,18 +240,13 @@ module.exports = yeoman.Base.extend({
     this.fs.copyTpl(
       this.templatePath('demo/_index.html'),
       this.destinationPath('demo/index.html'),
-      {
-        projectName: this.props.projectName
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('demo/_main.ts'),
       this.destinationPath('demo/src/main.ts'),
-      {
-        projectNameCamelCase: this.props.projectNameCamelCase,
-        projectName: this.props.projectName
-      }
+      this.props
     );
 
     this.fs.copy(
@@ -286,27 +277,19 @@ module.exports = yeoman.Base.extend({
     this.fs.copyTpl(
       this.templatePath('demo/_package.json'),
       this.destinationPath('demo/package.json'),
-      {
-        projectName: this.props.projectName,
-        description: this.props.description,
-        authorName: this.props.authorName
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('demo/_README.md'),
       this.destinationPath('demo/README.md'),
-      {
-        projectName: this.props.projectName
-      }
+      this.props
     );
 
     this.fs.copyTpl(
       this.templatePath('demo/_systemjs.config.js'),
       this.destinationPath('demo/systemjs.config.js'),
-      {
-        projectName: this.props.projectName
-      }
+      this.props
     );
   },
 

--- a/app/templates/_index.ts
+++ b/app/templates/_index.ts
@@ -1,18 +1,2 @@
-/*!
- * @license
- * Copyright 2016 Alfresco Software, Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+<%- licenseHeader %>
 export * from './src/<%= projectName %>.component';

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,9 +7,10 @@
     "postinstall": "typings install",
     "clean": "rimraf dist node_modules typings",
     "typings": "typings install",
-    "build": "npm run tslint && rimraf dist && tsc && npm run copy-dist && license-check",
+    "license-check": "echo 'license check is disabled'",
+    "build": "npm run tslint && rimraf dist && tsc && npm run copy-dist && npm run license-check",
     "build:w": "npm run tslint && rimraf dist && npm run watch-task",
-    "watch-task": "concurrently \"npm run tsc:w\"  \"npm run copy-dist:w\"  \"license-check\"",
+    "watch-task": "concurrently \"npm run tsc:w\"  \"npm run copy-dist:w\"  \"npm run license-check\"",
     "tslint": "tslint -c tslint.json *.ts && tslint -c tslint.json src/{,**/}**.ts",
     "copy-dist": "cpx \"./src/**/*.{html,css,json,png,jpg,gif,svg}\" ./dist/src",
     "copy-dist:w": "cpx \"./src/**/*.{html,css,json,png,jpg,gif,svg}\" ./dist/src -w",
@@ -61,7 +62,6 @@
     "karma-jasmine-ajax": "^0.1.13",
     "karma-jasmine-html-reporter": "^0.2.0",
     "karma-mocha-reporter": "^2.0.3",
-    "license-check": "^1.0.4",
     "remap-istanbul": "^0.6.3",
     "rimraf": "2.5.2",
     "traceur": "^0.0.91",
@@ -69,14 +69,5 @@
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "wsrv": "^0.1.3"
-  },
-  "license-check-config": {
-    "src": [
-      "./dist/**/*.js"
-    ],
-    "path": "assets/license_header.txt",
-    "blocking": false,
-    "logInfo": false,
-    "logError": true
   }
 }

--- a/app/templates/_sourceFile.ts
+++ b/app/templates/_sourceFile.ts
@@ -1,20 +1,4 @@
-/*!
- * @license
- * Copyright 2016 Alfresco Software, Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+<%- licenseHeader %>
 import { Component } from '@angular/core';
 
 @Component({

--- a/app/templates/_testFile.spec.ts
+++ b/app/templates/_testFile.spec.ts
@@ -1,20 +1,4 @@
-/*!
- * @license
- * Copyright 2016 Alfresco Software, Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+<%- licenseHeader %>
 import {describe, expect, it, inject, setBaseTestProviders} from '@angular/core/testing';
 import { TestComponentBuilder } from '@angular/compiler/testing';
 import {

--- a/app/templates/demo/_main.ts
+++ b/app/templates/demo/_main.ts
@@ -1,19 +1,4 @@
-/*!
- * @license
- * Copyright 2016 Alfresco Software, Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+<%- licenseHeader %>
 import { Component } from '@angular/core';
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { <%= projectNameCamelCase %>Component } from '<%= projectName %>';


### PR DESCRIPTION
- generate license checker configs (with —alfresco switch)
- generate license headers for TS files (with —alfresco switch)

closes #8 